### PR TITLE
pyvis 0.3.2 rebuild ❄️

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
   sha256: ff947e224d9825e4b0f3d6710075945c5c8d13bf60aa54e6396c996f34851a3a
   patches:
     - patches/0001-Fixed-tests-to-run-on-CI.patch
+    - patches/0002-Fix-version.patch
 
 build:
   skip: true  [py<=36]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,8 @@ test:
     - pip
   commands:
     - pip check
+    # check that pip gets the correct version
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     # test_html requires webdriver-manager, which isn't available yet
     - rm pyvis/tests/test_html.py
     - cd pyvis

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
 
 build:
   skip: true  [py<=36]
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
 
 requirements:

--- a/recipe/patches/0002-Fix-version.patch
+++ b/recipe/patches/0002-Fix-version.patch
@@ -1,0 +1,19 @@
+From cae38cd6b2a76ecd92e0b41ff2b35c32a1243d07 Mon Sep 17 00:00:00 2001
+From: Mohamed Sentissi <msentissi@anaconda.com>
+Date: Tue, 17 Dec 2024 16:12:28 -0500
+Subject: [PATCH] Fix version
+
+---
+ pyvis/_version.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pyvis/_version.py b/pyvis/_version.py
+index b4f711f..47a41e4 100644
+--- a/pyvis/_version.py
++++ b/pyvis/_version.py
+@@ -1 +1 @@
+-__version__ = '0.2.0' # bump version
++__version__ = '0.3.2' # bump version
+-- 
+2.45.2
+


### PR DESCRIPTION
pyvis 0.3.2 rebuild ❄️

**Destination channel:** Snowflake

### Links

- [PKG-6632](https://anaconda.atlassian.net/browse/PKG-6632) 
- [Upstream repository](https://github.com/WestHealth/pyvis/tree/v0.3.2)

### Explanation of changes:

- Rebuild to patch [wrong version specified](https://github.com/WestHealth/pyvis/blob/ccb7ce745ee4159ce45eac70b9848ab965fc0906/pyvis/_version.py#L1) upstream which fails `pip check` in dependent packages.


[PKG-6632]: https://anaconda.atlassian.net/browse/PKG-6632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ